### PR TITLE
Make -renormalize work on the top mip-level too (opt-out option)

### DIFF
--- a/crnlib/crn_mipmapped_texture.h
+++ b/crnlib/crn_mipmapped_texture.h
@@ -219,6 +219,7 @@ namespace crnlib
             m_wrapping(false),
             m_srgb(false),
             m_renormalize(false),
+            m_rtopmip(false),
             m_filter_scale(.9f),
             m_gamma(1.75f),    // or 2.2f
             m_multithreaded(true)
@@ -229,6 +230,7 @@ namespace crnlib
          bool        m_wrapping;
          bool        m_srgb;
          bool        m_renormalize;
+         bool        m_rtopmip;
          float       m_filter_scale;
          float       m_gamma;
          bool        m_multithreaded;

--- a/crnlib/crn_texture_comp.cpp
+++ b/crnlib/crn_texture_comp.cpp
@@ -430,7 +430,7 @@ namespace crnlib
       new_width = math::clamp<int>(new_width, 1, cCRNMaxLevelResolution);
       new_height = math::clamp<int>(new_height, 1, cCRNMaxLevelResolution);
 
-      if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height()))
+      if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height()) || (mipmap_params.m_renormalize != 0))
       {
          console::info("Resampling input texture to %ux%u", new_width, new_height);
 

--- a/crnlib/crn_texture_comp.cpp
+++ b/crnlib/crn_texture_comp.cpp
@@ -430,7 +430,7 @@ namespace crnlib
       new_width = math::clamp<int>(new_width, 1, cCRNMaxLevelResolution);
       new_height = math::clamp<int>(new_height, 1, cCRNMaxLevelResolution);
 
-      if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height()) || (mipmap_params.m_renormalize != 0))
+      if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height()) || (mipmap_params.m_renormalize == true && mipmap_params.m_rtopmip == true))
       {
          console::info("Resampling input texture to %ux%u", new_width, new_height);
 

--- a/crnlib/crn_texture_conversion.cpp
+++ b/crnlib/crn_texture_conversion.cpp
@@ -402,6 +402,7 @@ namespace crnlib
          console::debug("Gamma filtering: %u, Gamma: %2.2f", mipmap_params.m_gamma_filtering, mipmap_params.m_gamma);
          console::debug("     Blurriness: %2.2f", mipmap_params.m_blurriness);
          console::debug("    Renormalize: %u", mipmap_params.m_renormalize);
+         console::debug("Renorm. top mip: %u", mipmap_params.m_rtopmip);
          console::debug("          Tiled: %u", mipmap_params.m_tiled);
          console::debug("     Max Levels: %u", mipmap_params.m_max_levels);
          console::debug(" Min level size: %u", mipmap_params.m_min_mip_size);

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -146,6 +146,7 @@ public:
       console::printf("-blurriness # - Scale filter kernel, >1=blur, <1=sharpen, .01-8, default=.9");
       console::printf("-wrap - Assume texture is tiled when filtering, default=clamping");
       console::printf("-renormalize - Renormalize filtered normal map texels, default=disabled");
+      console::printf("-rtopmip - Renormalize on the top mip-level too, default=disabled");
       console::printf("-maxmips # - Limit number of generated texture mipmap levels, 1-16, default=16");
       console::printf("-minmipsize # - Smallest allowable mipmap resolution, default=1");
 
@@ -216,6 +217,7 @@ public:
          { "blurriness", 1, false },
          { "wrap", 0, false },
          { "renormalize", 0, false },
+         { "rtopmip", 0, false },
          { "noprogress", 0, false },
          { "paramdebug", 0, false },
          { "debug", 0, false },
@@ -763,6 +765,7 @@ private:
       mip_params.m_blurriness = m_params.get_value_as_float("blurriness", 0, mip_params.m_blurriness, .01f, 8.0f);
 
       mip_params.m_renormalize = m_params.get_value_as_bool("renormalize", 0, mip_params.m_renormalize != 0);
+      mip_params.m_rtopmip = m_params.get_value_as_bool("rtopmip", 0, mip_params.m_rtopmip != 0);
       mip_params.m_tiled = m_params.get_value_as_bool("wrap");
 
       mip_params.m_max_levels = m_params.get_value_as_int("maxmips", 0, cCRNMaxLevels, 1, cCRNMaxLevels);

--- a/inc/crnlib.h
+++ b/inc/crnlib.h
@@ -421,6 +421,7 @@ struct crn_mipmap_params
       // Default "blurriness" factor of .9 actually sharpens the output a little.
       m_blurriness = .9f;
       m_renormalize = false;
+      m_rtopmip = false;
       m_tiled = false;
       m_max_levels = cCRNMaxLevels;
       m_min_mip_size = 1;
@@ -451,6 +452,7 @@ struct crn_mipmap_params
       CRNLIB_COMP(m_gamma);
       CRNLIB_COMP(m_blurriness);
       CRNLIB_COMP(m_renormalize);
+      CRNLIB_COMP(m_rtopmip);
       CRNLIB_COMP(m_tiled);
       CRNLIB_COMP(m_max_levels);
       CRNLIB_COMP(m_min_mip_size);
@@ -481,6 +483,7 @@ struct crn_mipmap_params
    crn_uint32     m_min_mip_size;
 
    crn_bool       m_renormalize;
+   crn_bool       m_rtopmip;
    crn_bool       m_tiled;
 
    crn_scale_mode m_scale_mode;


### PR DESCRIPTION
For [Dæmon](https://github.com/DaemonEngine/Daemon)-based games like [Unvanquished](http://github.com/Unvanquished/Unvanquished/), we need to renormalize on the top of mip-level too.

Until now, we used an [old crunch fork](https://github.com/Unvanquished/crunch) that was patched by @gimhael on this purpose, he said at this time:

> Some tools scale the vectors in normalmaps to maximum length for
> increased precision, but that breaks reconstruction of the z part
> in DXN compressed normal maps. Passing -renormalize on compression
> fixes those textures now.

This PR reports the change to upstream, making it as an opt-out option to not change the default `-renormalize` behavior.

Dæmon engine users can do `crunch -renormalize -rtopmip` to get the behavior they need.