### PR TITLE
Avoid ambiguity error on GCC

### DIFF
--- a/crnlib/crn_vector.cpp
+++ b/crnlib/crn_vector.cpp
@@ -22,8 +22,8 @@ namespace crnlib
          return true;
 
       size_t new_capacity = min_new_capacity;
-      if ((grow_hint) && (!math::is_power_of_2(new_capacity)))
-         new_capacity = math::next_pow2(new_capacity);
+	  if ((grow_hint) && (!math::is_power_of_2((uint64)new_capacity)))
+		  new_capacity = math::next_pow2((uint64)new_capacity);
 
       CRNLIB_ASSERT(new_capacity && (new_capacity > m_capacity));
 


### PR DESCRIPTION
Without this change, the code will fail to compile gcc 4.8.4, due to ambiguity between 32/64bit versions of is_power_of_2