### PR TITLE
crn_dxt1.cpp: add initialization of m_num_prev_results member

### DIFF
--- a/crnlib/crn_dxt1.cpp
+++ b/crnlib/crn_dxt1.cpp
@@ -53,6 +53,7 @@ namespace crnlib
 
       m_lo_cells.reserve(128);
       m_hi_cells.reserve(128);
+      m_num_prev_results = 0;
    }
 
    void dxt1_endpoint_optimizer::clear()


### PR DESCRIPTION
Without that initialization, compression results might be non
reproducible.