### PR TITLE
Fixed typo in command list

### DIFF
--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -115,7 +115,7 @@ public:
 
       console::message("\nImage rescaling (mutually exclusive options)");
       console::printf("-rescale <int> <int> - Rescale image to specified resolution");
-      console::printf("-relscale <float> <float> - Rescale image to specified relative resolution");
+      console::printf("-relrescale <float> <float> - Rescale image to specified relative resolution");
       console::printf("-rescalemode <nearest | hi | lo> - Auto-rescale non-power of two images");
       console::printf(" nearest - Use nearest power of 2, hi - Use next, lo - Use previous");
 


### PR DESCRIPTION
- Renamed `relscale` to `relrescale`