### PR TITLE
Fix crnlib compilation on MSVC 2022 toolchain

### DIFF
--- a/crnlib/crn_timer.h
+++ b/crnlib/crn_timer.h
@@ -49,7 +49,7 @@ namespace crnlib
       timer m_tm;
 
    public:
-      inline timed_scope(char* pName = "timed_scope") : m_pName(pName) { m_tm.start(); }
+      inline timed_scope(const char* pName = "timed_scope") : m_pName(pName) { m_tm.start(); }
       
       inline double get_elapsed_secs() const { return m_tm.get_elapsed_secs(); }
       inline double get_elapsed_ms() const { return m_tm.get_elapsed_ms(); }


### PR DESCRIPTION
Fix crnlib compilation on recent MSVC 2022 toolchain.